### PR TITLE
fix: clashing env var

### DIFF
--- a/.github/workflows/ex-publish.yml
+++ b/.github/workflows/ex-publish.yml
@@ -36,7 +36,7 @@ jobs:
         if: github.event_name == 'push'
         env:
           HEX_API_KEY: ${{ secrets.HEX_AUTH_TOKEN }}
-          PRERELEASE_VERSION: dev.${{ env.short_sha }}
+          LOGFLARE_EX_PRERELEASE_VERSION: dev.${{ env.short_sha }}
       - run: mix hex.publish --yes
         if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         env:

--- a/logflare-ex/mix.exs
+++ b/logflare-ex/mix.exs
@@ -1,7 +1,7 @@
 defmodule LogflareEx.MixProject do
   use Mix.Project
 
-  @prerelease System.get_env("PRERELEASE_VERSION")
+  @prerelease System.get_env("LOGFLARE_EX_PRERELEASE_VERSION")
   @version_suffix if(@prerelease, do: "-#{@prerelease}", else: "")
   def project do
     [


### PR DESCRIPTION
Clashing env var during compilation results in version differences