### PR TITLE
logflare-ex/fix: tesla post case clause

### DIFF
--- a/logflare-ex/lib/logflare_ex.ex
+++ b/logflare-ex/lib/logflare_ex.ex
@@ -63,10 +63,10 @@ defmodule LogflareEx do
     body = Bertex.encode(%{"batch" => batch, "source" => client.source_token})
 
     case Tesla.post(client.tesla_client, "/api/logs", body) do
-      %Tesla.Env{status: 201, body: body} ->
+      {:ok, %Tesla.Env{status: status, body: body}} when status < 300 ->
         {:ok, Jason.decode!(body)}
 
-      %Tesla.Env{} = result ->
+      {:error, %Tesla.Env{} = result} ->
         # on_error callback
         case Map.get(client, :on_error) do
           {m, f, 1} -> apply(m, f, [result])

--- a/logflare-ex/test/batcher_test.exs
+++ b/logflare-ex/test/batcher_test.exs
@@ -100,7 +100,9 @@ defmodule LogflareEx.BatcherTest do
   describe "Batcher genserver" do
     setup do
       Tesla
-      |> stub(:post, fn _client, _path, _body -> %Tesla.Env{status: 200, body: "ok"} end)
+      |> stub(:post, fn _client, _path, _body ->
+        {:ok, %Tesla.Env{status: 200, body: Jason.encode!(%{})}}
+      end)
 
       :ok
     end

--- a/logflare-ex/test/logger_backend_test.exs
+++ b/logflare-ex/test/logger_backend_test.exs
@@ -38,7 +38,7 @@ defmodule LogflareEx.LoggerBackendTest do
       |> expect(:post, 1, fn _client, _path, body ->
         batch = Bertex.decode(body)["batch"]
         assert length(batch) == 10
-        %Tesla.Env{status: 201, body: Jason.encode!(%{"message" => "server msg"})}
+        {:ok, %Tesla.Env{status: 201, body: Jason.encode!(%{"message" => "server msg"})}}
       end)
 
       assert LogflareEx.count_queued_events() == 0
@@ -289,7 +289,7 @@ defmodule LogflareEx.LoggerBackendTest do
     |> stub(:post, fn _client, _path, body ->
       batch = Bertex.decode(body)["batch"]
       send(pid, batch)
-      %Tesla.Env{status: 201, body: Jason.encode!(%{"message" => "server msg"})}
+      {:ok, %Tesla.Env{status: 201, body: Jason.encode!(%{"message" => "server msg"})}}
     end)
 
     :ok

--- a/logflare-ex/test/telemetry_reporter_test.exs
+++ b/logflare-ex/test/telemetry_reporter_test.exs
@@ -20,7 +20,7 @@ defmodule LogflareEx.TelemetryReporterTest do
     test "handle_attach/4" do
       Tesla
       |> expect(:post, fn _client, _path, _body ->
-        %Tesla.Env{status: 201, body: Jason.encode!(%{"message" => "server msg"})}
+        {:ok, %Tesla.Env{status: 201, body: Jason.encode!(%{"message" => "server msg"})}}
       end)
 
       :telemetry.attach("my-id", [:some, :event], &TelemetryReporter.handle_attach/4,
@@ -46,7 +46,7 @@ defmodule LogflareEx.TelemetryReporterTest do
     test "metrics opt" do
       Tesla
       |> expect(:post, fn _client, _path, _body ->
-        %Tesla.Env{status: 201, body: Jason.encode!(%{"message" => "server msg"})}
+        {:ok, %Tesla.Env{status: 201, body: Jason.encode!(%{"message" => "server msg"})}}
       end)
 
       start_supervised!(


### PR DESCRIPTION
```
d.

[error] [] Task #PID<0.8642.0> started from #PID<0.8641.0> terminating
** (CaseClauseError) no case clause matching: {:ok, %Tesla.Env{method: :post, url: "http://localhost:4000/api/logs", query: [], headers: [{"date", "Mon, 27 Nov 2023 08:10:25 GMT"}, {"vary", "accept-encoding"}, {"content-type", "application/json; charset=utf-8"}, {"cache-control", "max-age=0, private, must-revalidate"}, {"x-request-id", "F5tsipRjuS5VZJ8AADoB"}, {"logflare-node", "orange@ty-mpb"}, {"x-rate-limit-user_limit", "600000000"}, {"x-rate-limit-user_remaining", "599999873"}, {"x-rate-limit-source_limit", "1500"}, {"x-rate-limit-source_remaining", "1462"}, {"access-control-allow-origin", "*"}, {"access-control-expose-headers", ""}, {"access-control-allow-credentials", "true"}], body: "{\"message\":\"Logged!\"}", status: 200, opts: [], __module__: Tesla, __client__: %Tesla.Client{fun: nil, pre: [{Tesla.Middleware.FollowRedirects, :call, [[]]}, {Tesla.Middleware.Headers, :call, [[{"x-api-key", "Gl7cv2t7Up6B"}, {"content-type", "application/bert"}]]}, {Tesla.Middleware.BaseUrl, :call, ["http://localhost:4000"]}, {Tesla.Middleware.Compression, :call, [[format: "gzip"]]}], post: [], adapter: {Tesla.Adapter.Finch, :call, [[name: LogflareEx.Finch, receive_timeout: 30000]]}}}}
    (logflare_ex 0.2.0) lib/logflare_ex.ex:65: LogflareEx.send_events/2
    (logflare_ex 0.2.0) lib/batcher.ex:225: anonymous fn/3 in LogflareEx.Batcher.flush_events/1
    (elixir 1.15.5) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2
Function: #Function<2.85234490/0 in LogflareEx.Batcher.flush_events/1>
    Args: []
```
`post/4` returns tuple result