### PR TITLE
logflare-ex/fix: handle_info flushing

### DIFF
--- a/logflare-ex/lib/logflare_ex/logger_backend.ex
+++ b/logflare-ex/lib/logflare_ex/logger_backend.ex
@@ -104,6 +104,11 @@ defmodule LogflareEx.LoggerBackend do
     {:ok, state}
   end
 
+  def handle_info(:flush, state) do
+    LogflareEx.flush(state.client)
+    {:ok, state}
+  end
+
   def handle_call({:configure, options}, _config) do
     config = build_default_config(options)
     maybe_start(config)


### PR DESCRIPTION
Apparently `handle_info/2` handler needs to be provided as well

```

[error] [] :gen_event handler LogflareEx.LoggerBackend installed in Logger terminating
** (FunctionClauseError) no function clause matching in LogflareEx.LoggerBackend.handle_info/2
    (logflare_ex 0.2.0) lib/logflare_ex/logger_backend.ex:102: LogflareEx.LoggerBackend.handle_info({Logger.Backends.Config, :update_counter}, %{level: :all, client: %LogflareEx.Client{batch_size: 200, flush_interval: 1000, auto_flush: true, on_error: nil, source_name: nil, source_token: "3da605a5-5d49-4421-8ee9-51dab70a423e", api_url: "http://localhost:4000", api_key: "Gl7cv2t7Up6B", tesla_client: %Tesla.Client{fun: nil, pre: [{Tesla.Middleware.FollowRedirects, :call, [[]]}, {Tesla.Middleware.Headers, :call, [[{"x-api-key", "Gl7cv2t7Up6B"}, {"content-type", "application/bert"}]]}, {Tesla.Middleware.BaseUrl, :call, ["http://localhost:4000"]}, {Tesla.Middleware.Compression, :call, [[format: "gzip"]]}], post: [], adapter: {Tesla.Adapter.Finch, :call, [[name: LogflareEx.Finch, receive_timeout: 30000]]}}}})
    (stdlib 5.0.2) gen_event.erl:802: :gen_event.server_update/4
    (stdlib 5.0.2) gen_event.erl:784: :gen_event.server_notify/4
    (stdlib 5.0.2) gen_event.erl:573: :gen_event.handle_msg/6
    (stdlib 5.0.2) proc_lib.erl:241: :proc_lib.init_p_do_apply/3
Last message: {Logger.Backends.Config, :update_counter}
```