### PR TITLE
chore: update pre-release tagging

### DIFF
--- a/.github/workflows/ex-publish.yml
+++ b/.github/workflows/ex-publish.yml
@@ -31,12 +31,13 @@ jobs:
           key: mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: mix
       - run: mix deps.get
-      - run: echo "short_sha=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
+      - run: echo "short_sha=`echo ${GITHUB_SHA} | cut -c1-7`" >> $GITHUB_ENV
+      - run: echo "timestamp=`date +%s`" >> $GITHUB_ENV
       - run: mix hex.publish --yes
         if: github.event_name == 'push'
         env:
           HEX_API_KEY: ${{ secrets.HEX_AUTH_TOKEN }}
-          LOGFLARE_EX_PRERELEASE_VERSION: dev+${{ env.short_sha }}
+          LOGFLARE_EX_PRERELEASE_VERSION: dev.${{env.timestamp}}.${{ env.short_sha }}
       - run: mix hex.publish --yes
         if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         env:


### PR DESCRIPTION
Changes pre-release tagging, because hex doesn;'t like it when I use the sha.
- uses unix timestamp to allow solver to work correctly when choosing latest prerelease
- adds sha at the tail end with additional dot separator, because hex doesn't accept build metadata (even though it is part of semver).