### PR TITLE
fix: :on_error callback should handle 500s errors

### DIFF
--- a/logflare-ex/lib/logflare_ex.ex
+++ b/logflare-ex/lib/logflare_ex.ex
@@ -66,7 +66,7 @@ defmodule LogflareEx do
       {:ok, %Tesla.Env{status: status, body: body}} when status < 300 ->
         {:ok, Jason.decode!(body)}
 
-      {:error, %Tesla.Env{} = result} ->
+      {_result, %Tesla.Env{} = result} ->
         # on_error callback
         case Map.get(client, :on_error) do
           {m, f, 1} -> apply(m, f, [result])

--- a/logflare-ex/test/logflare_ex_test.exs
+++ b/logflare-ex/test/logflare_ex_test.exs
@@ -66,7 +66,6 @@ defmodule LogflareExTest do
       end
     end
 
-
     test "triggers on_error mfa on tesla client error" do
       Tesla
       |> expect(:post, 2, fn _client, _path, _body ->
@@ -84,7 +83,6 @@ defmodule LogflareExTest do
         assert {:error, %Tesla.Env{}} = LogflareEx.send_events(client, [%{some: "event"}])
       end
     end
-
   end
 
   describe "batching" do

--- a/logflare-ex/test/logflare_ex_test.exs
+++ b/logflare-ex/test/logflare_ex_test.exs
@@ -23,7 +23,7 @@ defmodule LogflareExTest do
 
     Tesla
     |> expect(:post, fn _client, _path, _body ->
-      {:error, %Tesla.Env{status: 500, body: "server err"}}
+      {:ok, %Tesla.Env{status: 500, body: "server err"}}
     end)
 
     assert {:error, %Tesla.Env{}} = LogflareEx.send_event(client, %{some: "event"})
@@ -51,6 +51,25 @@ defmodule LogflareExTest do
     test "triggers on_error mfa if non-201 status is encountered" do
       Tesla
       |> expect(:post, 2, fn _client, _path, _body ->
+        {:ok, %Tesla.Env{status: 500, body: "some server error"}}
+      end)
+
+      LogflareEx.TestUtils
+      |> expect(:stub_function, 2, fn %{status: 500} -> :ok end)
+
+      for cb <- [
+            {LogflareEx.TestUtils, :stub_function, 1},
+            &LogflareEx.TestUtils.stub_function/1
+          ] do
+        client = LogflareEx.client(api_key: "123", source_token: "123", on_error: cb)
+        assert {:error, %Tesla.Env{}} = LogflareEx.send_events(client, [%{some: "event"}])
+      end
+    end
+
+
+    test "triggers on_error mfa on tesla client error" do
+      Tesla
+      |> expect(:post, 2, fn _client, _path, _body ->
         {:error, %Tesla.Env{status: 500, body: "some server error"}}
       end)
 
@@ -65,6 +84,7 @@ defmodule LogflareExTest do
         assert {:error, %Tesla.Env{}} = LogflareEx.send_events(client, [%{some: "event"}])
       end
     end
+
   end
 
   describe "batching" do


### PR DESCRIPTION
`:on_error` callback should handle 500s errors with an :ok tuple from tesla